### PR TITLE
fixed styles for correct display of onebox previews

### DIFF
--- a/assets/stylesheets/design_bundles_settings.scss
+++ b/assets/stylesheets/design_bundles_settings.scss
@@ -1,3 +1,9 @@
 .settings .setting .setting-label {
   width: 30%;
 }
+
+//fix for correct display of onebox previews
+.ytp-thumbnail-image {
+  max-width: none !important;
+  max-height: none !important;
+}


### PR DESCRIPTION
changes in styles that are designed to correctly display the YouTube link

![image](https://user-images.githubusercontent.com/30925506/97571638-82121280-19f0-11eb-9663-97ad866c9779.png)
![image](https://user-images.githubusercontent.com/30925506/97571792-8d653e00-19f0-11eb-8c35-da32e1d38a9a.png)
